### PR TITLE
feat: 작업 1. 2. .env를 분리하고 프로젝트 셋업에서 다시 합치도록 스크립트 및 env 수정 (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,8 @@
 /storage/*.key
 /vendor
 .env
-.env.backup
-.env.production
-.env.example
+.env.*
+
 .phpunit.result.cache
 Homestead.json
 Homestead.yaml

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+source ./.env.core
+
+rm -f ./.env
+
+if [ "$APP_ENV" = "production" ]; then
+    rm -f /usr/local/etc/php/conf.d/xdebug.ini
+    cat ./.env.core ./.env.production > ./.env
+else
+    rm -f /usr/local/etc/php/conf.d/opcache.ini
+    rm -f /usr/local/etc/php/conf.d/jit.ini
+    cat ./.env.core ./.env.local > ./.env
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd app/every-discussion-backend
 git pull
-sudo docker compose down
-sudo docker compose up -d --build
+docker compose --env-file .env.core down
+docker compose --env-file .env.core up -d --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,7 @@
 version: "1"
 services:
     webserver:
-        build:
-            context: ./docker/php
-            dockerfile: Dockerfile
-            args:
-                APP_ENV: ${APP_ENV}
+        build: docker/php
         ports:
             - "0.0.0.0:${APP_PORT}:80"
             - "0.0.0.0:${APP_PORT_SSL}:443"
@@ -13,7 +9,7 @@ services:
             - .:/var/www/html
             - /var/www/html/vendor
             - ./docker/ssl:/etc/ssl/docker
-        command: sh -c "composer install && (php artisan horizon &) && (php artisan schedule:work &) && apachectl -D FOREGROUND"
+        command: sh -c "./build.sh && composer install && (php artisan horizon &) && (php artisan schedule:work &) && apachectl -D FOREGROUND"
         restart: always
     mysql:
         image: mysql:latest

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,7 +1,5 @@
 FROM php:8.2-apache
-
-ARG APP_ENV
-ENV APP_ENV=${APP_ENV}
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 RUN apt-get update && \
     apt-get install -y \
@@ -18,9 +16,6 @@ RUN pecl install redis
 RUN docker-php-ext-install pdo_mysql zip opcache curl pcntl
 RUN docker-php-ext-enable pdo_mysql zip opcache curl pcntl redis
 COPY conf.d /usr/local/etc/php/conf.d
-RUN if [ "$APP_ENV" = "production" ]; then \
-        rm -f /usr/local/etc/php/conf.d/xdebug.ini; \
-    fi
 
 ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf


### PR DESCRIPTION
기존 .env는 .env.core가 되고 production과 local 변경해야할 부분은 각각 .env.lcoal, .env.production에 저장해서 쓰면된다. docker compose가 실행될때 스크립트가 실행되어 .env 파일 하나로 뽑아준다.