### PR TITLE
chore: MySQL, Redis 실행 후에 웹서버 실행

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
             - ./docker/ssl:/etc/ssl/docker
         command: sh -c "./build.sh && apachectl -D FOREGROUND"
         restart: always
+        depends_on:
+            mysql:
+                condition: service_started
+            redis:
+                condition: service_started
     mysql:
         image: mysql:latest
         command: --default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
이전의 세팅에선, 웹서버가 실행될 때 Redis 연결 실패 메시지가 뜨는 문제가 있어서 이를 해결